### PR TITLE
Rename skill directories from plan-issue/implement-issue to plan/implement

### DIFF
--- a/github-devflow/skills/implement/SKILL.md
+++ b/github-devflow/skills/implement/SKILL.md
@@ -1,5 +1,4 @@
 ---
-name: implement-issue
 description: This skill should be used when the user asks to "implement an issue", "create a PR for issue", "implement issue #123", "turn this issue into code", or wants to implement a GitHub issue following an implementation plan and create a pull request.
 argument-hint: "<issue-number>"
 disable-model-invocation: true

--- a/github-devflow/skills/plan/SKILL.md
+++ b/github-devflow/skills/plan/SKILL.md
@@ -1,5 +1,4 @@
 ---
-name: plan-issue
 description: Creates an implementation plan for a GitHub issue and posts it as a comment. Triggered when the user provides a GitHub issue number for planning.
 argument-hint: "<issue-number>"
 disable-model-invocation: true


### PR DESCRIPTION
## Summary

- Simplify skill directory names by removing the `-issue` suffix
- Makes command invocations more concise (e.g., `/plan` instead of `/plan-issue`)

## Test plan

- [x] Verify `/plan` skill works correctly
- [x] Verify `/implement` skill works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)